### PR TITLE
Update dependency on compile-testing to 0.18

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.google.testing.compile:compile-testing:0.15")
+    implementation("com.google.testing.compile:compile-testing:0.18")
 
     // jUnit5 API
     api(platform("org.junit:junit-bom:5.3.2"))


### PR DESCRIPTION
I ran into this library from this thread on compile-testing https://github.com/google/compile-testing/pull/155 after having exactly the same problem (i.e. I'm using JUnit 5). 

I have to admit that I didn't quite understand the difference between `compile` / `implementation` / `api` when I thought about updating the dependency on compile-testing (now I get it!) so this is relatively inconsequential. Still, it's probably a good idea to track compile-testing.

Thanks for the library!
